### PR TITLE
Allow base16-bytestring-1.0

### DIFF
--- a/resolv.cabal
+++ b/resolv.cabal
@@ -93,7 +93,7 @@ library
 
   -- we need binary-0.7.3 for isolate
   build-depends:     base               >= 4.5 && <4.15
-                   , base16-bytestring ^>= 0.1
+                   , base16-bytestring ^>= 0.1 || ^>=1.0.0.0
                    , binary            ^>=0.7.3 || ^>= 0.8
                    , bytestring        ^>=0.9.2 || ^>= 0.10
                    , containers        ^>=0.4.2.1 || ^>= 0.5 || ^>= 0.6
@@ -113,7 +113,7 @@ test-suite resolv.
                , bytestring
 
   -- additional dependencies not inherited
-  build-depends: tasty        ^>= 1.2.3
+  build-depends: tasty        ^>= 1.2.3 || ^>=1.3.1
                , tasty-hunit  ^>= 0.10.0
                , directory    ^>= 1.1.0 || ^>= 1.2.0 || ^>= 1.3.0
                , filepath     ^>= 1.3.0 || ^>= 1.4.0

--- a/src/Network/DNS/Message.hs
+++ b/src/Network/DNS/Message.hs
@@ -17,6 +17,7 @@ module Network.DNS.Message where
 import qualified Data.ByteString.Base16 as B16
 
 import qualified Data.ByteString        as BS
+import qualified Data.ByteString.Char8  as BS.Char8
 import qualified Data.ByteString.Lazy   as BSL
 import           Data.Function
 import           Data.List              (groupBy)
@@ -83,7 +84,10 @@ newtype Name = Name BS.ByteString
 -- The limit of 255 octets is caused by the encoding which uses by a
 -- prefixed octet denoting the length.
 newtype CharStr = CharStr BS.ByteString
-                deriving (Eq,Ord,IsString)
+                deriving (Eq,Ord)
+
+instance IsString CharStr where
+    fromString = CharStr . BS.Char8.pack
 
 instance Show CharStr where
     showsPrec p (CharStr bs) = showsPrec p bs


### PR DESCRIPTION
Also fix build issue with older bytestring,
which doesn't have IsString instance

Travis build: https://travis-ci.org/github/haskell-hvr/resolv/builds/727960870