### PR TITLE
res_ninit() requires cleanup with res_nclose()

### DIFF
--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -75,6 +75,14 @@ hs_res_query(struct __res_state *s, const char *dname, int class, int type, unsi
   return res_nquery(s, dname, class, type, answer, anslen);
 }
 
+inline static void
+hs_res_nclose(struct __res_state *s)
+{
+  assert(s);
+
+  res_nclose(s);
+}
+
 #else
 
 /* use non-reentrant API */
@@ -121,6 +129,11 @@ hs_res_query(void *s, const char *dname, int class, int type, unsigned char *ans
   assert(!s);
 
   return res_query(dname, class, type, answer, anslen);
+}
+
+inline static void
+hs_res_nclose(struct __res_state *s)
+{
 }
 
 #endif

--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -75,8 +75,11 @@ hs_res_query(struct __res_state *s, const char *dname, int class, int type, unsi
   return res_nquery(s, dname, class, type, answer, anslen);
 }
 
+/* res_nclose() finalizes resources allocated by res_ninit() and subsequent
+ * calls to res_nquery() */
+
 inline static void
-hs_res_nclose(struct __res_state *s)
+hs_res_close(struct __res_state *s)
 {
   assert(s);
 
@@ -132,7 +135,7 @@ hs_res_query(void *s, const char *dname, int class, int type, unsigned char *ans
 }
 
 inline static void
-hs_res_nclose(struct __res_state *s)
+hs_res_close(void *s)
 {
 }
 

--- a/src/Network/DNS.hs
+++ b/src/Network/DNS.hs
@@ -152,16 +152,21 @@ queryRaw (Class cls) (Name name) qtype = withCResState $ \stptr -> do
             resetErrno
             reslen <- c_res_query stptr dn (fromIntegral cls) qtypeVal resptr max_msg_size
 
-            unless (reslen <= max_msg_size) $
+            unless (reslen <= max_msg_size) $ do
+                c_res_nclose stptr
                 fail "res_query(3) message size overflow"
 
             errno <- getErrno
 
             when (reslen < 0) $ do
-                unless (errno == eOK) $
+                unless (errno == eOK) $ do
+                    c_res_nclose stptr
                     throwErrno "res_query"
 
+                c_res_nclose stptr
                 fail "res_query(3) failed"
+
+            c_res_nclose stptr
 
             BS.packCStringLen (resptr, fromIntegral reslen)
 
@@ -188,16 +193,21 @@ sendRaw req = withCResState $ \stptr -> do
             resetErrno
             reslen <- c_res_send stptr reqptr (fromIntegral reqlen) resptr max_msg_size
 
-            unless (reslen <= max_msg_size) $
+            unless (reslen <= max_msg_size) $ do
+                c_res_nclose stptr
                 fail "res_send(3) message size overflow"
 
             errno <- getErrno
 
             when (reslen < 0) $ do
-                unless (errno == eOK) $
+                unless (errno == eOK) $ do
+                    c_res_nclose stptr
                     throwErrno "res_send"
 
+                c_res_nclose stptr
                 fail "res_send(3) failed"
+
+            c_res_nclose stptr
 
             BS.packCStringLen (resptr, fromIntegral reslen)
 
@@ -256,16 +266,21 @@ mkQueryRaw (Class cls) (Name name) qtype = withCResState $ \stptr -> do
             resetErrno
             reslen <- c_res_mkquery stptr dn (fromIntegral cls) qtypeVal resptr max_msg_size
 
-            unless (reslen <= max_msg_size) $
+            unless (reslen <= max_msg_size) $ do
+                c_res_nclose stptr
                 fail "res_mkquery(3) message size overflow"
 
             errno <- getErrno
 
             when (reslen < 0) $ do
-                unless (errno == eOK) $
+                unless (errno == eOK) $ do
+                    c_res_nclose stptr
                     throwErrno "res_query"
 
+                c_res_nclose stptr
                 fail "res_mkquery(3) failed"
+
+            c_res_nclose stptr
 
             BS.packCStringLen (resptr, fromIntegral reslen)
 

--- a/src/Network/DNS.hs
+++ b/src/Network/DNS.hs
@@ -140,27 +140,27 @@ query cls name0 qtype
 --
 -- You can use 'decodeMessage' to decode the response message.
 queryRaw :: Class -> Name -> Type -> IO BS.ByteString
-queryRaw (Class cls) (Name name) qtype = withCResState $ \stptr ->
+queryRaw (Class cls) (Name name) qtype = withCResState $ \stptr -> do
     allocaBytes max_msg_size $ \resptr -> do
         _ <- c_memset resptr 0 max_msg_size
-        BS.useAsCString name $ \dn ->
+        BS.useAsCString name $ \dn -> do
 
-            withCResInit stptr $ do
+          withCResInit stptr $ do
 
-                reslen <- c_res_query stptr dn (fromIntegral cls) qtypeVal resptr max_msg_size
+            reslen <- c_res_query stptr dn (fromIntegral cls) qtypeVal resptr max_msg_size
 
-                unless (reslen <= max_msg_size) $
-                    fail "res_query(3) message size overflow"
+            unless (reslen <= max_msg_size) $
+                fail "res_query(3) message size overflow"
 
-                errno <- getErrno
+            errno <- getErrno
 
-                when (reslen < 0) $ do
-                    unless (errno == eOK) $
-                        throwErrno "res_query"
+            when (reslen < 0) $ do
+                unless (errno == eOK) $
+                    throwErrno "res_query"
 
-                    fail "res_query(3) failed"
+                fail "res_query(3) failed"
 
-                BS.packCStringLen (resptr, fromIntegral reslen)
+            BS.packCStringLen (resptr, fromIntegral reslen)
 
   where
     -- The DNS protocol is inherently 16-bit-offset based; so 64KiB is
@@ -174,27 +174,26 @@ queryRaw (Class cls) (Name name) qtype = withCResState $ \stptr ->
 
 -- | Send a raw preformatted query via @res_send(3)@.
 sendRaw :: BS.ByteString -> IO BS.ByteString
-sendRaw req = withCResState $ \stptr ->
+sendRaw req = withCResState $ \stptr -> do
     allocaBytes max_msg_size $ \resptr -> do
         _ <- c_memset resptr 0 max_msg_size
-        BS.useAsCStringLen req $ \(reqptr,reqlen) ->
+        BS.useAsCStringLen req $ \(reqptr,reqlen) -> do
 
-            withCResInit stptr $ do
+          withCResInit stptr $ do
+            reslen <- c_res_send stptr reqptr (fromIntegral reqlen) resptr max_msg_size
 
-                reslen <- c_res_send stptr reqptr (fromIntegral reqlen) resptr max_msg_size
+            unless (reslen <= max_msg_size) $
+                fail "res_send(3) message size overflow"
 
-                unless (reslen <= max_msg_size) $
-                    fail "res_send(3) message size overflow"
+            errno <- getErrno
 
-                errno <- getErrno
+            when (reslen < 0) $ do
+                unless (errno == eOK) $
+                    throwErrno "res_send"
 
-                when (reslen < 0) $ do
-                    unless (errno == eOK) $
-                        throwErrno "res_send"
+                fail "res_send(3) failed"
 
-                    fail "res_send(3) failed"
-
-                BS.packCStringLen (resptr, fromIntegral reslen)
+            BS.packCStringLen (resptr, fromIntegral reslen)
 
   where
     -- The DNS protocol is inherently 16-bit-offset based; so 64KiB is
@@ -239,27 +238,27 @@ mkQueryMsg cls l qtype = Msg (MsgHeader{..})
 
 -- | Use @res_mkquery(3)@ to construct a DNS query message.
 mkQueryRaw :: Class -> Name -> Type -> IO BS.ByteString
-mkQueryRaw (Class cls) (Name name) qtype = withCResState $ \stptr ->
+mkQueryRaw (Class cls) (Name name) qtype = withCResState $ \stptr -> do
     allocaBytes max_msg_size $ \resptr -> do
         _ <- c_memset resptr 0 max_msg_size
-        BS.useAsCString name $ \dn ->
+        BS.useAsCString name $ \dn -> do
 
-            withCResInit stptr $ do
+          withCResInit stptr $ do
 
-                reslen <- c_res_mkquery stptr dn (fromIntegral cls) qtypeVal resptr max_msg_size
+            reslen <- c_res_mkquery stptr dn (fromIntegral cls) qtypeVal resptr max_msg_size
 
-                unless (reslen <= max_msg_size) $
-                    fail "res_mkquery(3) message size overflow"
+            unless (reslen <= max_msg_size) $
+                fail "res_mkquery(3) message size overflow"
 
-                errno <- getErrno
+            errno <- getErrno
 
-                when (reslen < 0) $ do
-                    unless (errno == eOK) $
-                        throwErrno "res_query"
+            when (reslen < 0) $ do
+                unless (errno == eOK) $
+                    throwErrno "res_query"
 
-                    fail "res_mkquery(3) failed"
+                fail "res_mkquery(3) failed"
 
-                BS.packCStringLen (resptr, fromIntegral reslen)
+            BS.packCStringLen (resptr, fromIntegral reslen)
 
   where
     -- The DNS protocol is inherently 16-bit-offset based; so 64KiB is

--- a/src/Network/DNS/FFI.hs
+++ b/src/Network/DNS/FFI.hs
@@ -68,3 +68,6 @@ foreign import capi safe "hs_resolv.h res_opt_set_use_dnssec" c_res_opt_set_use_
 -- int hs_res_mkquery(void *, const char *dname, int class, int type, unsigned char *req, int reqlen0);
 foreign import capi safe "hs_resolv.h hs_res_mkquery" c_res_mkquery :: Ptr CResState -> CString -> CInt -> CInt -> Ptr CChar -> CInt -> IO CInt
 
+-- void hs_res_nclose(void *);
+foreign import capi safe "hs_resolv.h hs_res_nclose" c_res_nclose :: Ptr CResState -> IO ()
+

--- a/src/Network/DNS/FFI.hs
+++ b/src/Network/DNS/FFI.hs
@@ -4,6 +4,8 @@
 module Network.DNS.FFI where
 
 import           Control.Concurrent.MVar
+import           Control.Monad           (unless)
+import           Control.Exception       (finally)
 import           Foreign.C
 import           Foreign.Marshal.Alloc
 import           Foreign.Ptr
@@ -52,6 +54,14 @@ withCResState act
                          act ptr
   | otherwise = withMVar resolvLock $ \() -> act nullPtr
 
+withCResInit :: Ptr CResState -> IO a -> IO a
+withCResInit stptr act = do
+   rc1 <- c_res_opt_set_use_dnssec stptr
+   unless (rc1 == 0) $
+       fail "res_init(3) failed"
+   resetErrno
+   act `finally` c_res_close stptr
+
 
 -- void *memset(void *s, int c, size_t n);
 foreign import capi unsafe "string.h memset" c_memset :: Ptr a -> CInt -> CSize -> IO (Ptr a)
@@ -68,6 +78,6 @@ foreign import capi safe "hs_resolv.h res_opt_set_use_dnssec" c_res_opt_set_use_
 -- int hs_res_mkquery(void *, const char *dname, int class, int type, unsigned char *req, int reqlen0);
 foreign import capi safe "hs_resolv.h hs_res_mkquery" c_res_mkquery :: Ptr CResState -> CString -> CInt -> CInt -> Ptr CChar -> CInt -> IO CInt
 
--- void hs_res_nclose(void *);
-foreign import capi safe "hs_resolv.h hs_res_nclose" c_res_nclose :: Ptr CResState -> IO ()
+-- void hs_res_close(void *);
+foreign import capi safe "hs_resolv.h hs_res_close" c_res_close :: Ptr CResState -> IO ()
 

--- a/src/Network/DNS/FFI.hs
+++ b/src/Network/DNS/FFI.hs
@@ -55,12 +55,12 @@ withCResState act
   | otherwise = withMVar resolvLock $ \() -> act nullPtr
 
 withCResInit :: Ptr CResState -> IO a -> IO a
-withCResInit stptr act = do
-   rc1 <- c_res_opt_set_use_dnssec stptr
-   unless (rc1 == 0) $
-       fail "res_init(3) failed"
-   resetErrno
-   act `finally` c_res_close stptr
+withCResInit stptr act = flip finally (c_res_close stptr) $ do
+     rc1 <- c_res_opt_set_use_dnssec stptr
+     unless (rc1 == 0) $
+         fail "res_init(3) failed"
+     resetErrno
+     act
 
 
 -- void *memset(void *s, int c, size_t n);


### PR DESCRIPTION
Linux man 3 resolver says:
    Every call to res_ninit() requires a corresponding call to
    res_nclose() to free memory allocated by res_ninit() and subsequent
    calls to res_nquery().

I use the library for periodic DNS polls from multiple async threads. Before the fix it was leaking.