### PR TITLE
Bump bytestring to >= 0.10 for correct IsString ByteString instance

### DIFF
--- a/resolv.cabal
+++ b/resolv.cabal
@@ -68,7 +68,6 @@ tested-with:
   -- GHC == 7.10.3
   -- GHC == 7.8.4
   -- GHC == 7.6.3
-  -- GHC == 7.4.2
 
 source-repository head
   type:              git
@@ -95,11 +94,14 @@ library
                      Compat
 
   -- we need binary-0.7.3 for isolate
-  build-depends:     base               >= 4.5     && < 4.18
-                   , base16-bytestring  >= 0.1     && < 1.1
-                   , binary            ^>= 0.7.3   || ^>= 0.8
-                   , bytestring         >= 0.9.2   && < 0.12
-                   , containers        ^>= 0.4.2.1 || ^>= 0.5  || ^>= 0.6
+  build-depends:     base               >= 4.6      && < 4.18
+                       -- bytestring-0.10.0.0 was shipped with GHC 7.6 (base-4.6)
+                   , base16-bytestring  >= 0.1      && < 1.1
+                   , binary            ^>= 0.7.3    || ^>= 0.8
+                   , bytestring         >= 0.10.0.0 && < 0.12
+                       -- instance IsString ByteString exists in its form since bytestring-0.10.0.0
+                       -- see https://github.com/haskell-hvr/resolv/pull/13#issuecomment-1213876161
+                   , containers        ^>= 0.4.2.1  || ^>= 0.5  || ^>= 0.6
 
   ghc-options:       -Wall
   include-dirs:      cbits


### PR DESCRIPTION
Bump `bytestring` to >= 0.10 for correct `IsString ByteString` instance.
See https://github.com/haskell-hvr/resolv/pull/13#issuecomment-1213876161

This PR delivers a fix contained (in different form) in PRs:
- #13 
- #10