### PR TITLE
Throw h_errno specific exceptions after res_query errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /dist-newstyle/
 /.ghc.environment.*
 /dist/
+/.stack-work/
+/stack*.lock
 /resolv.buildinfo
 /configure
 /config.log

--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -9,6 +9,10 @@
 # include <netinet/in.h>
 #endif
 
+#if defined(HAVE_DECL_H_ERRNO)
+#  include <netdb.h>
+#endif
+
 #if defined(HAVE_ARPA_NAMESER_H)
 # include <arpa/nameser.h>
 #endif
@@ -123,6 +127,27 @@ hs_res_query(void *s, const char *dname, int class, int type, unsigned char *ans
   return res_query(dname, class, type, answer, anslen);
 }
 
+#endif
+
+#if defined(HAVE_DECL_H_ERRNO)
+inline static int
+hs_get_h_errno()
+{
+  switch(h_errno)
+  {
+    case HOST_NOT_FOUND: return 1;
+    case NO_DATA: return 2;
+    case NO_RECOVERY: return 3;
+    case TRY_AGAIN: return 4;
+    default:  return -1;
+  }
+}
+#else
+inline static int
+hs_get_h_errno()
+{
+  return -1;
+}
 #endif
 
 #endif /* HS_RESOLV_H */

--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -90,6 +90,8 @@ hs_res_close(struct __res_state *s)
   res_nclose(s);
 }
 
+#if defined(HAVE_DECL_H_ERRNO)
+
 #if defined(HAVE_STRUCT___RES_STATE_RES_H_ERRNO)
 
 inline static int
@@ -107,7 +109,7 @@ hs_get_h_errno(struct __res_state *s)
   }
 }
 
-#elif defined(HAVE_DECL_H_ERRNO)
+#else
 
 inline static int
 hs_get_h_errno(struct __res_state *s)
@@ -121,6 +123,8 @@ hs_get_h_errno(struct __res_state *s)
     default:  return -1;
   }
 }
+
+#endif
 
 #else
 

--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -42,6 +42,7 @@
     case NO_DATA:        return 2;   \
     case NO_RECOVERY:    return 3;   \
     case TRY_AGAIN:      return 4;   \
+    case 0:              return 0;   \
     default:             return -1;  \
   }
 

--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -34,6 +34,17 @@
 # error broken invariant
 #endif
 
+/* Macro to calculate error code returned by hs_get_h_errno */
+#define __HS_GET_H_ERRNO(h_errno)    \
+  switch(h_errno)                    \
+  {                                  \
+    case HOST_NOT_FOUND: return 1;   \
+    case NO_DATA:        return 2;   \
+    case NO_RECOVERY:    return 3;   \
+    case TRY_AGAIN:      return 4;   \
+    default:             return -1;  \
+  }
+
 #if USE_RES_NQUERY
 
 inline static int
@@ -92,39 +103,16 @@ hs_res_close(struct __res_state *s)
 
 #if defined(HAVE_DECL_H_ERRNO)
 
+inline static int
+hs_get_h_errno(struct __res_state *s)
+{
 #if defined(HAVE_STRUCT___RES_STATE_RES_H_ERRNO)
-
-inline static int
-hs_get_h_errno(struct __res_state *s)
-{
   assert(s);
-
-  switch(s->res_h_errno)
-  {
-    case HOST_NOT_FOUND: return 1;
-    case NO_DATA: return 2;
-    case NO_RECOVERY: return 3;
-    case TRY_AGAIN: return 4;
-    default:  return -1;
-  }
-}
-
+  __HS_GET_H_ERRNO(s->res_h_errno)
 #else
-
-inline static int
-hs_get_h_errno(struct __res_state *s)
-{
-  switch(h_errno)
-  {
-    case HOST_NOT_FOUND: return 1;
-    case NO_DATA: return 2;
-    case NO_RECOVERY: return 3;
-    case TRY_AGAIN: return 4;
-    default:  return -1;
-  }
-}
-
+  __HS_GET_H_ERRNO(h_errno)
 #endif
+}
 
 #else
 
@@ -134,9 +122,9 @@ hs_get_h_errno(struct __res_state *s)
   return -1;
 }
 
-#endif
+#endif /* HAVE_DECL_H_ERRNO */
 
-#else
+#else  /* USE_RES_NQUERY */
 
 /* use non-reentrant API */
 
@@ -194,14 +182,7 @@ hs_res_close(void *s)
 inline static int
 hs_get_h_errno(void *s)
 {
-  switch(h_errno)
-  {
-    case HOST_NOT_FOUND: return 1;
-    case NO_DATA: return 2;
-    case NO_RECOVERY: return 3;
-    case TRY_AGAIN: return 4;
-    default:  return -1;
-  }
+  __HS_GET_H_ERRNO(h_errno)
 }
 
 #else
@@ -212,8 +193,8 @@ hs_get_h_errno(void *s)
   return -1;
 }
 
-#endif
+#endif /* HAVE_DECL_H_ERRNO */
 
-#endif
+#endif /* USE_RES_NQUERY */
 
 #endif /* HS_RESOLV_H */

--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -101,28 +101,20 @@ hs_res_close(struct __res_state *s)
   res_nclose(s);
 }
 
-#if defined(HAVE_DECL_H_ERRNO)
-
 inline static int
 hs_get_h_errno(struct __res_state *s)
 {
+#if defined(HAVE_DECL_H_ERRNO)
 #if defined(HAVE_STRUCT___RES_STATE_RES_H_ERRNO)
   assert(s);
   __HS_GET_H_ERRNO(s->res_h_errno)
 #else
   __HS_GET_H_ERRNO(h_errno)
 #endif
-}
-
 #else
-
-inline static int
-hs_get_h_errno(struct __res_state *s)
-{
   return -1;
+#endif
 }
-
-#endif /* HAVE_DECL_H_ERRNO */
 
 #else  /* USE_RES_NQUERY */
 
@@ -177,23 +169,15 @@ hs_res_close(void *s)
 {
 }
 
+inline static int
+hs_get_h_errno(void *s)
+{
 #if defined(HAVE_DECL_H_ERRNO)
-
-inline static int
-hs_get_h_errno(void *s)
-{
   __HS_GET_H_ERRNO(h_errno)
-}
-
 #else
-
-inline static int
-hs_get_h_errno(void *s)
-{
   return -1;
+#endif
 }
-
-#endif /* HAVE_DECL_H_ERRNO */
 
 #endif /* USE_RES_NQUERY */
 

--- a/cbits/hs_resolv.h
+++ b/cbits/hs_resolv.h
@@ -10,7 +10,7 @@
 #endif
 
 #if defined(HAVE_DECL_H_ERRNO)
-#  include <netdb.h>
+# include <netdb.h>
 #endif
 
 #if defined(HAVE_ARPA_NAMESER_H)
@@ -90,6 +90,48 @@ hs_res_close(struct __res_state *s)
   res_nclose(s);
 }
 
+#if defined(HAVE_STRUCT___RES_STATE_RES_H_ERRNO)
+
+inline static int
+hs_get_h_errno(struct __res_state *s)
+{
+  assert(s);
+
+  switch(s->res_h_errno)
+  {
+    case HOST_NOT_FOUND: return 1;
+    case NO_DATA: return 2;
+    case NO_RECOVERY: return 3;
+    case TRY_AGAIN: return 4;
+    default:  return -1;
+  }
+}
+
+#elif defined(HAVE_DECL_H_ERRNO)
+
+inline static int
+hs_get_h_errno(struct __res_state *s)
+{
+  switch(h_errno)
+  {
+    case HOST_NOT_FOUND: return 1;
+    case NO_DATA: return 2;
+    case NO_RECOVERY: return 3;
+    case TRY_AGAIN: return 4;
+    default:  return -1;
+  }
+}
+
+#else
+
+inline static int
+hs_get_h_errno(struct __res_state *s)
+{
+  return -1;
+}
+
+#endif
+
 #else
 
 /* use non-reentrant API */
@@ -143,11 +185,10 @@ hs_res_close(void *s)
 {
 }
 
-#endif
-
 #if defined(HAVE_DECL_H_ERRNO)
+
 inline static int
-hs_get_h_errno()
+hs_get_h_errno(void *s)
 {
   switch(h_errno)
   {
@@ -158,12 +199,17 @@ hs_get_h_errno()
     default:  return -1;
   }
 }
+
 #else
+
 inline static int
-hs_get_h_errno()
+hs_get_h_errno(void *s)
 {
   return -1;
 }
+
+#endif
+
 #endif
 
 #endif /* HS_RESOLV_H */

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,10 @@ AC_CHECK_DECLS([res_query, res_nquery], [], [], [[
 #include <resolv.h>
 ]])
 
+AC_CHECK_DECLS([h_errno], [], [], [[
+#include <netdb.h>
+]])
+
 dnl ----------------------------------------------------------------------------
 
 RESOLV_SEARCH_LIBS([res_query],[res_query(0,0,0,0,0)],[resolv bind],[EXTRA_LIBS="$EXTRA_LIBS $ac_lib"],[

--- a/configure.ac
+++ b/configure.ac
@@ -71,14 +71,6 @@ USE_RES_NQUERY=0
 AC_MSG_WARN([could not figure out which C library contains res_nquery(3)])
 ])
 
-else
-
-AC_MSG_WARN([could not determine sizeof(struct __res_state)])
-
-fi
-
-fi
-
 AC_CHECK_MEMBERS([struct __res_state.res_h_errno],[],[],[[
 #include <sys/types.h>
 #ifdef HAVE_NETINET_IN_H
@@ -89,6 +81,14 @@ AC_CHECK_MEMBERS([struct __res_state.res_h_errno],[],[],[[
 #endif
 #include <resolv.h>
 ]])
+
+else
+
+AC_MSG_WARN([could not determine sizeof(struct __res_state)])
+
+fi
+
+fi
 
 AC_MSG_CHECKING([which DNS api to use])
 

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,17 @@ fi
 
 fi
 
+AC_CHECK_MEMBERS([struct __res_state.res_h_errno],[],[],[[
+#include <sys/types.h>
+#ifdef HAVE_NETINET_IN_H
+# include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+# include <arpa/nameser.h>
+#endif
+#include <resolv.h>
+]])
+
 AC_MSG_CHECKING([which DNS api to use])
 
 case "x$USE_RES_NQUERY" in

--- a/src/Network/DNS.hs
+++ b/src/Network/DNS.hs
@@ -162,13 +162,13 @@ queryRaw (Class cls) (Name name) qtype = withCResState $ \stptr -> do
                 unless (errno == eOK) $
                     throwErrno "res_query"
 
-                h_errno <- c_get_h_errno
+                h_errno <- c_get_h_errno stptr
                 case h_errno of
-                  1 -> throw DnsHostNotFound
-                  2 -> throw DnsNoData
-                  3 -> throw DnsNoRecovery
-                  4 -> throw DnsTryAgain
-                  _ -> fail "res_query (3) failed"
+                    1 -> throwIO DnsHostNotFound
+                    2 -> throwIO DnsNoData
+                    3 -> throwIO DnsNoRecovery
+                    4 -> throwIO DnsTryAgain
+                    _ -> fail "res_query(3) failed"
 
             BS.packCStringLen (resptr, fromIntegral reslen)
 

--- a/src/Network/DNS.hs
+++ b/src/Network/DNS.hs
@@ -101,13 +101,26 @@ import           Network.DNS.Message
 -- | Exception thrown in case of errors while resolving or encoding/decoding into a 'Msg'.
 --
 -- @since 0.1.1.0
-data DnsException = DnsEncodeException
-                  | DnsDecodeException
-                  | DnsHostNotFound -- ^ No such domain (authoritative)
-                  | DnsNoData       -- ^ No record for requested type
-                  | DnsNoRecovery   -- ^ Non recoverable errors, REFUSED, NOTIMP
-                  | DnsTryAgain     -- ^ No such domain (non-authoritative) or SERVERFAIL
-                  deriving (Show, Typeable)
+data DnsException
+  = DnsEncodeException
+  | DnsDecodeException
+  | DnsHostNotFound
+      -- ^ No such domain (authoritative)
+      --
+      -- @since 0.2.0.0
+  | DnsNoData
+      -- ^ No record for requested type
+      --
+      -- @since 0.2.0.0
+  | DnsNoRecovery
+      -- ^ Non recoverable errors, REFUSED, NOTIMP
+      --
+      -- @since 0.2.0.0
+  | DnsTryAgain
+      -- ^ No such domain (non-authoritative) or SERVERFAIL
+      --
+      -- @since 0.2.0.0
+  deriving (Show, Typeable)
 
 instance Exception DnsException
 

--- a/src/Network/DNS/FFI.hs
+++ b/src/Network/DNS/FFI.hs
@@ -68,3 +68,5 @@ foreign import capi safe "hs_resolv.h res_opt_set_use_dnssec" c_res_opt_set_use_
 -- int hs_res_mkquery(void *, const char *dname, int class, int type, unsigned char *req, int reqlen0);
 foreign import capi safe "hs_resolv.h hs_res_mkquery" c_res_mkquery :: Ptr CResState -> CString -> CInt -> CInt -> Ptr CChar -> CInt -> IO CInt
 
+-- void *get_h_errno(void *s, int c, size_t n);
+foreign import capi unsafe "hs_resolv.h hs_get_h_errno" c_get_h_errno :: IO CInt

--- a/src/Network/DNS/FFI.hs
+++ b/src/Network/DNS/FFI.hs
@@ -82,5 +82,5 @@ foreign import capi safe "hs_resolv.h hs_res_mkquery" c_res_mkquery :: Ptr CResS
 -- void hs_res_close(void *);
 foreign import capi safe "hs_resolv.h hs_res_close" c_res_close :: Ptr CResState -> IO ()
 
--- void *hs_get_h_errno(void *s, int c, size_t n);
-foreign import capi unsafe "hs_resolv.h hs_get_h_errno" c_get_h_errno :: IO CInt
+-- void *hs_get_h_errno(void *);
+foreign import capi unsafe "hs_resolv.h hs_get_h_errno" c_get_h_errno :: Ptr CResState -> IO CInt


### PR DESCRIPTION
`resolv` currently ignores h_errno and only produces a generic user error when res_query fails.

This PR forwards h_errno as different DnsException constructors when h_errno is available.